### PR TITLE
Add success value to bench results

### DIFF
--- a/lib/macroperf.mli
+++ b/lib/macroperf.mli
@@ -270,7 +270,8 @@ end
 
 module Summary : sig
   module Aggr : sig
-    type t = { mean: float;
+    type t = { success: bool;
+               mean: float;
                stddev: float;
                mini: float;
                maxi: float;
@@ -279,14 +280,14 @@ module Summary : sig
 
     include Sexpable.S with type t := t
 
-    val create : mean:float -> stddev:float ->
+    val create : success:bool -> mean:float -> stddev:float ->
       mini:float -> maxi:float -> runs:int -> t
 
     val compare : t -> t -> int
     val max : t -> t -> t
     val min : t -> t -> t
 
-    val of_measures : Measure.t list -> t
+    val of_measures : success:bool -> Measure.t list -> t
     (** [of_measures weight m] is a t *)
 
     val normalize : t -> t
@@ -302,6 +303,7 @@ module Summary : sig
   end
 
   type t = {
+    success: bool;
     name: string;
     context_id: string;
     weight: float;

--- a/src/injector.ml
+++ b/src/injector.ml
@@ -104,12 +104,14 @@ let export
   in
   let summaries = List.map
       (fun (name, data) ->
+         let success = true in
          let cy_a, cy_b, cy_min, cy_max = Core_bench_data.(affine_adjustment ~what:cycles data) in
          let na_a, na_b, na_min, na_max = Core_bench_data.(affine_adjustment ~what:nanos data) in
          let runs = List.length data in
-         let cy_aggr = Summary.Aggr.create ~mean:cy_a ~stddev:0. ~mini:cy_min ~maxi:cy_max ~runs in
-         let na_aggr = Summary.Aggr.create ~mean:na_a ~stddev:0. ~mini:na_min ~maxi:na_max ~runs in
+         let cy_aggr = Summary.Aggr.create ~success ~mean:cy_a ~stddev:0. ~mini:cy_min ~maxi:cy_max ~runs in
+         let na_aggr = Summary.Aggr.create ~success ~mean:na_a ~stddev:0. ~mini:na_min ~maxi:na_max ~runs in
          Summary.{
+           success;
            name; context_id; weight;
            data = TMap.add
                Topic.(Topic ("cycles", Perf)) cy_aggr


### PR DESCRIPTION
and mark all processes that didn't return 0 as failed. Should avoid most cases
of silent failures in the future...
